### PR TITLE
Sort and remove duplicate languages for dropdown menu

### DIFF
--- a/github/repo_data.rb
+++ b/github/repo_data.rb
@@ -17,7 +17,7 @@ module Github
     end
 
     def languages
-      @languages.keys.sort {|a,b| @languages[b] <=> @languages[a] }
+      @languages.keys.sort.uniq { |language| language.downcase }
     end
 
     def manipulate_resource_list(resources)


### PR DESCRIPTION
Sort and remove duplicate languages (there was `JavaScript` and `Javascript`).