### PR TITLE
Fix capitalization on sort dropdown menu

### DIFF
--- a/source/includes/_navbar.erb
+++ b/source/includes/_navbar.erb
@@ -14,7 +14,7 @@
           <option value="stars" selected>Sorted by stars</option>
           <option value="forks">Sorted by forks</option>
           <option value="issues">Sorted by issues</option>
-          <option value="title">sorted by title</option>
+          <option value="title">Sorted by title</option>
         </select>
       </div>
     <% end %>


### PR DESCRIPTION
`Sorted by title` rather than `sorted by title`. :smile: 