### PR TITLE
Fix select arrow appearing on Firefox

### DIFF
--- a/source/stylesheets/all.css
+++ b/source/stylesheets/all.css
@@ -386,6 +386,9 @@ pre {
   border: 0;
   border-radius: 0;
   -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px; /* Fix select appearance on Firefox https://gist.github.com/joaocunha/6273016/ */
+  text-overflow: '';
 }
 
 .dropdown-select:focus {


### PR DESCRIPTION
No more select arrow on Firefox. :smile: 

![](https://www.evernote.com/shard/s93/sh/45e6fe86-3078-4de8-a70c-5cf7e359cdee/9ec7aa08fa4b447c794394b081f39990/res/a8344687-8363-4fa8-858e-59980ad62750/skitch.png) ![](https://www.evernote.com/shard/s93/sh/57e83b56-5680-4ace-a1ea-b7671cecf036/b3c83282e465a82827dfabab6521d9d9/res/e8dad320-3654-40fd-add0-7603be5b26d6/skitch.png)